### PR TITLE
Update detection_time key in PinnaDetector

### DIFF
--- a/algos/pinia.md
+++ b/algos/pinia.md
@@ -188,7 +188,7 @@ Pinna 検出器の大まかな処理フローは以下のとおりである。
       'offsets': np.ndarray,      # オフセット時刻(秒)
       'intervals': np.ndarray,    # shape (N_notes, 2) の [開始, 終了] 時刻
       'pitches': np.ndarray,      # shape (N_notes,) の各ノートピッチ(Hz)
-      'detector_time': float,     # 処理時間(秒)
+      'detection_time': float,    # 処理時間(秒)
       'name': str                 # 検出器名 (PinnaDetector)
   }
   ```

--- a/src/detectors/pinia_detector.py
+++ b/src/detectors/pinia_detector.py
@@ -137,7 +137,7 @@ class PinnaDetector(BaseDetector):
             "offsets": offsets,
             "intervals": intervals,
             "pitches": pitches,
-            "detector_time": time.time() - start_time,
+            "detection_time": time.time() - start_time,
             "name": self.__class__.__name__,
         }
 


### PR DESCRIPTION
## Summary
- rename return key `detector_time` to `detection_time` in PinnaDetector
- update related documentation

## Testing
- `python -m pytest -q tests/unit/utils/test_detection_result.py::test_detection_result_creation` *(fails: No module named pytest)*